### PR TITLE
Use Merge to Prevent Duplicated Data

### DIFF
--- a/sqlalchemy_seed/__init__.py
+++ b/sqlalchemy_seed/__init__.py
@@ -103,7 +103,8 @@ def load_fixtures(session, fixtures):
             instances.append(instance)
 
     try:
-        session.add_all(instances)
+        for instance in instances:
+            session.merge(instance)
         session.flush()
         session.commit()
     except Exception:


### PR DESCRIPTION
I noticed that using this tool was not idempotent, and was causing integrity errors on subsequent runs due to an attempt to insert the same primary keys multiple times. Since I would imagine that inserting this fixture data into the database should behave similarly to database migrations (in that they should be able to be run repeatedly as part of a deployment pipeline), I adjusted the `add_all` to `merge`. While slower, I believe that this functionality of inserting the data only when it has changed or does not already exist is what is actually desired.